### PR TITLE
Fix QCompleter popup position to appear below cursor

### DIFF
--- a/shoggoth/text_editor.py
+++ b/shoggoth/text_editor.py
@@ -273,6 +273,7 @@ class ArkhamTextEdit(QTextEdit):
                 self.completer.popup().sizeHintForColumn(0)
                 + self.completer.popup().verticalScrollBar().sizeHint().width()
             )
+            cursor_rect.translate(0, cursor_rect.height())
             self.completer.complete(cursor_rect)
             self.completing = True
         else:
@@ -329,7 +330,7 @@ class LabeledArkhamTextEdit(QTextEdit):
         layout.addWidget(self.input)
         
         self.container.setLayout(layout)
-    
+
     def toPlainText(self):
         return self.input.toPlainText()
     


### PR DESCRIPTION
- Offset popup by cursor height to prevent obscuring text being completed
- Uses translate() on cursor_rect before calling complete()