### PR TITLE
Support for Environment Variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# This is an example for a .env file
+# Copy it, rename it to .env, uncomment the relevant lines below and edit them.
+# SHOGGOTH_ASSET_DIR="C:/path/to/your/custom/assets"

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ settings.json
 /test_case/*.jpeg
 /test_case/*.png
 /test_case/*.webp
+.env

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "beautifulsoup4>=4.14.3",
     "markdown>=3.7",
     "pillow-jxl-plugin>=1.3.7",
+    "python-dotenv>=1.2.2",
 ]
 
 [project.urls]

--- a/shoggoth/files.py
+++ b/shoggoth/files.py
@@ -7,7 +7,14 @@ import shoggoth
 dirs = PlatformDirs("Shoggoth", "Shoggoth")
 root_dir = Path(dirs.user_data_dir)
 
-asset_dir = root_dir / "assets"
+# Check if a custom asset directory is set via environment variable
+custom_asset_dir = os.environ.get("SHOGGOTH_ASSET_DIR")
+
+if custom_asset_dir:
+    asset_dir = Path(custom_asset_dir)
+else:
+    asset_dir = root_dir / "assets"
+
 defaults_dir = asset_dir / "defaults"
 font_dir = asset_dir / "fonts"
 overlay_dir = asset_dir / "overlays"

--- a/shoggoth/run.py
+++ b/shoggoth/run.py
@@ -4,6 +4,10 @@ Simple run script for Shoggoth PySide6 version
 """
 import sys
 from pathlib import Path
+from dotenv import load_dotenv
+
+# Load environment variables from .env
+load_dotenv()
 
 # Add the parent directory to Python path so we can import shoggoth modules
 parent_dir = Path(__file__).parent.parent


### PR DESCRIPTION
Adds support for environment variables and a .env example.

The only used variable atm is `SHOGGOTH_ASSET_DIR`, which can be set to override the default folder for assets.