### PR TITLE
SE-Exporter: Use ZoopGUID if possible

### DIFF
--- a/ShoggothExporter.js
+++ b/ShoggothExporter.js
@@ -816,6 +816,13 @@ function convert_card(path, collection, image_folder) {
         out["name"] = file_parts[file_parts.length - 1];
     }
 
+    // id from existing Zoop GUID if possible
+    let zoopGuid = settings.get("TtsZoopGuid");
+    if (zoopGuid) {
+        out["id"] = zoopGuid;
+        println("  TtsZoopGuid: " + zoopGuid);
+    }
+
     // front/back types
     out["front"] = {
         type: front_types[script_name],

--- a/shoggoth/tts_lib.py
+++ b/shoggoth/tts_lib.py
@@ -4,6 +4,7 @@ from shoggoth import files
 from shoggoth.export_helpers import build_gm_notes_string
 from copy import deepcopy
 from pathlib import Path
+import re
 from shoggoth import renderer
 from shoggoth import tts_sync
 
@@ -208,6 +209,10 @@ TYPE_TAG_MAP = {
 }
 
 
+def remove_formatting_tags(text: str) -> str:
+    return re.sub(r"</?[^>]+>", "", text)
+
+
 def card_to_tts(card, id, number, image_folder):
     data = deepcopy(card_template)
     data['CustomDeck'][id] = deepcopy(inner_card_template)
@@ -229,7 +234,7 @@ def card_to_tts(card, id, number, image_folder):
             data['Tags'].append(tag)
 
     data['Description'] = card.get('subtitle')
-    data['Nickname'] = card.name
+    data['Nickname'] = remove_formatting_tags(card.name)
     data['CardID'] = id * 100
     data['GMNotes'] = build_gm_notes_string(card)
     return data


### PR DESCRIPTION
Updates the SE export script to initialize the new shoggoth card with the ZoopGUID as `id` if available.