### PR TITLE
Updated TTS Export for horizontal cards

### DIFF
--- a/shoggoth/tts_lib.py
+++ b/shoggoth/tts_lib.py
@@ -233,6 +233,16 @@ def card_to_tts(card, id, number, image_folder):
         if tag:
             data['Tags'].append(tag)
 
+    # handling for horizontal cards (since they get scaled differently by TTS)
+    if card_type in ['Act', 'Agenda', 'Investigator']:
+        data['Transform']['scaleX'] *= 0.8214
+        data['Transform']['scaleZ'] *= 0.8214
+
+    # handling for investigators (since they are larger in TTS for clarity)
+    if card_type == 'Investigator':
+        data['Transform']['scaleX'] *= 1.15
+        data['Transform']['scaleZ'] *= 1.15
+
     data['Description'] = card.get('subtitle')
     data['Nickname'] = remove_formatting_tags(card.name)
     data['CardID'] = id * 100


### PR DESCRIPTION
Horizontal cards are differently scaled in TTS, so the "actual" scale has to be 0.8214 to achieve the same size as vertical cards.

Additionally, investigators are 15% larger in TTS for easier readability.

This PR handles both cases.